### PR TITLE
Resolve ID references via helper module

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -1,0 +1,133 @@
+const DEFAULT_IGNORED_PROPERTIES = ['id', 'realmId', 'owner'];
+
+function buildIgnoreSet(customIgnore) {
+  const ignore = new Set(DEFAULT_IGNORED_PROPERTIES);
+  if (!customIgnore) {
+    return ignore;
+  }
+
+  const values = Array.isArray(customIgnore)
+    ? customIgnore
+    : typeof customIgnore === 'string'
+      ? customIgnore.split(',')
+      : [];
+
+  for (const key of values) {
+    if (typeof key === 'string' && key.trim()) {
+      ignore.add(key.trim());
+    }
+  }
+
+  return ignore;
+}
+
+function isPlainObject(value) {
+  return Object.prototype.toString.call(value) === '[object Object]';
+}
+
+function formatPrimitive(value) {
+  if (value === null) {
+    return 'null';
+  }
+  if (typeof value === 'string') {
+    return `"${value}"`;
+  }
+  return String(value);
+}
+
+function collectNamedEntities(value, referenceMap = new Map()) {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectNamedEntities(item, referenceMap);
+    }
+    return referenceMap;
+  }
+
+  if (!isPlainObject(value)) {
+    return referenceMap;
+  }
+
+  const keys = Object.keys(value);
+  const idKey = keys.find((key) => key.toLowerCase() === 'id');
+  const nameKey = keys.find((key) => key.toLowerCase() === 'name');
+
+  if (idKey && nameKey) {
+    const idValue = value[idKey];
+    const nameValue = value[nameKey];
+    if (typeof idValue === 'string' && typeof nameValue === 'string') {
+      referenceMap.set(idValue, nameValue);
+    }
+  }
+
+  for (const key of keys) {
+    collectNamedEntities(value[key], referenceMap);
+  }
+
+  return referenceMap;
+}
+
+function resolveReferenceValue(key, value, referenceMap) {
+  if (
+    typeof key === 'string' &&
+    typeof value === 'string' &&
+    key.toLowerCase().endsWith('id') &&
+    referenceMap instanceof Map
+  ) {
+    const referenced = referenceMap.get(value);
+    if (referenced !== undefined) {
+      return referenced;
+    }
+  }
+  return value;
+}
+
+function describeValue(value, ignoreSet, indentLevel, lines, referenceMap) {
+  const indent = '  '.repeat(indentLevel);
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      lines.push(`${indent}The list is empty.`);
+      return;
+    }
+
+    lines.push(`${indent}The list has ${value.length} item${value.length === 1 ? '' : 's'}:`);
+    value.forEach((item, index) => {
+      if (isPlainObject(item) || Array.isArray(item)) {
+        lines.push(`${indent}  ${index + 1}.`);
+        describeValue(item, ignoreSet, indentLevel + 2, lines, referenceMap);
+      } else {
+        lines.push(`${indent}  ${index + 1}. ${formatPrimitive(item)}.`);
+      }
+    });
+    return;
+  }
+
+  if (isPlainObject(value)) {
+    const entries = Object.entries(value).filter(([key]) => !ignoreSet.has(key));
+    if (entries.length === 0) {
+      lines.push(`${indent}No relevant properties.`);
+      return;
+    }
+
+    lines.push(`${indent}The object has ${entries.length} propert${entries.length === 1 ? 'y' : 'ies'}:`);
+    for (const [key, val] of entries) {
+      if (isPlainObject(val) || Array.isArray(val)) {
+        lines.push(`${indent}  - ${key}:`);
+        describeValue(val, ignoreSet, indentLevel + 2, lines, referenceMap);
+      } else {
+        const resolvedValue = resolveReferenceValue(key, val, referenceMap);
+        lines.push(`${indent}  - ${key}: ${formatPrimitive(resolvedValue)}.`);
+      }
+    }
+    return;
+  }
+
+  lines.push(`${indent}${formatPrimitive(value)}.`);
+}
+
+module.exports = {
+  DEFAULT_IGNORED_PROPERTIES,
+  buildIgnoreSet,
+  describeValue,
+  collectNamedEntities,
+};

--- a/index.js
+++ b/index.js
@@ -5,85 +5,12 @@ const path = require('path');
 const yargs = require('yargs/yargs');
 const { hideBin } = require('yargs/helpers');
 
-const DEFAULT_IGNORED_PROPERTIES = ['id', 'realmId', 'owner'];
-
-function buildIgnoreSet(customIgnore) {
-  const ignore = new Set(DEFAULT_IGNORED_PROPERTIES);
-  if (!customIgnore) {
-    return ignore;
-  }
-
-  const values = Array.isArray(customIgnore)
-    ? customIgnore
-    : typeof customIgnore === 'string'
-      ? customIgnore.split(',')
-      : [];
-
-  for (const key of values) {
-    if (typeof key === 'string' && key.trim()) {
-      ignore.add(key.trim());
-    }
-  }
-
-  return ignore;
-}
-
-function isPlainObject(value) {
-  return Object.prototype.toString.call(value) === '[object Object]';
-}
-
-function formatPrimitive(value) {
-  if (value === null) {
-    return 'null';
-  }
-  if (typeof value === 'string') {
-    return `"${value}"`;
-  }
-  return String(value);
-}
-
-function describeValue(value, ignoreSet, indentLevel, lines) {
-  const indent = '  '.repeat(indentLevel);
-
-  if (Array.isArray(value)) {
-    if (value.length === 0) {
-      lines.push(`${indent}The list is empty.`);
-      return;
-    }
-
-    lines.push(`${indent}The list has ${value.length} item${value.length === 1 ? '' : 's'}:`);
-    value.forEach((item, index) => {
-      if (isPlainObject(item) || Array.isArray(item)) {
-        lines.push(`${indent}  ${index + 1}.`);
-        describeValue(item, ignoreSet, indentLevel + 2, lines);
-      } else {
-        lines.push(`${indent}  ${index + 1}. ${formatPrimitive(item)}.`);
-      }
-    });
-    return;
-  }
-
-  if (isPlainObject(value)) {
-    const entries = Object.entries(value).filter(([key]) => !ignoreSet.has(key));
-    if (entries.length === 0) {
-      lines.push(`${indent}No relevant properties.`);
-      return;
-    }
-
-    lines.push(`${indent}The object has ${entries.length} propert${entries.length === 1 ? 'y' : 'ies'}:`);
-    for (const [key, val] of entries) {
-      if (isPlainObject(val) || Array.isArray(val)) {
-        lines.push(`${indent}  - ${key}:`);
-        describeValue(val, ignoreSet, indentLevel + 2, lines);
-      } else {
-        lines.push(`${indent}  - ${key}: ${formatPrimitive(val)}.`);
-      }
-    }
-    return;
-  }
-
-  lines.push(`${indent}${formatPrimitive(value)}.`);
-}
+const {
+  DEFAULT_IGNORED_PROPERTIES,
+  buildIgnoreSet,
+  collectNamedEntities,
+  describeValue,
+} = require('./helpers');
 
 function jsonToCtb(data, options = {}) {
   const { ignore, output } = options;
@@ -99,7 +26,8 @@ function jsonToCtb(data, options = {}) {
   }
 
   const lines = ['Canonical Text Block', '--------------------'];
-  describeValue(source, ignoreSet, 0, lines);
+  const referenceMap = collectNamedEntities(source);
+  describeValue(source, ignoreSet, 0, lines, referenceMap);
 
   const result = lines.join('\n');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "license": "ISC",
       "dependencies": {
         "yargs": "^17.7.2"
+      },
+      "bin": {
+        "json2ctb": "index.js"
       }
     },
     "node_modules/ansi-regex": {


### PR DESCRIPTION
## Summary
- extract helper utilities to a dedicated helpers module
- collect referenced records and substitute names for matching *Id fields
- ensure Canonical Text Block generation uses the new helper logic

## Testing
- node index.js --input examples/multi-records.json

------
https://chatgpt.com/codex/tasks/task_e_68d7ea735e588327923d868d574b1105