### PR TITLE
Update xref key labeling in CTB output

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -81,6 +81,21 @@ function resolveReferenceValue(key, value, referenceMap) {
   return value;
 }
 
+function formatReferenceKey(key, value, referenceMap) {
+  if (
+    typeof key === 'string' &&
+    typeof value === 'string' &&
+    key.toLowerCase().endsWith('id') &&
+    referenceMap instanceof Map &&
+    referenceMap.has(value)
+  ) {
+    const baseKey = key.slice(0, -2);
+    return `${baseKey}-xref`;
+  }
+
+  return key;
+}
+
 function describeValue(value, ignoreSet, indentLevel, lines, referenceMap) {
   const indent = '  '.repeat(indentLevel);
 
@@ -116,7 +131,8 @@ function describeValue(value, ignoreSet, indentLevel, lines, referenceMap) {
         describeValue(val, ignoreSet, indentLevel + 2, lines, referenceMap);
       } else {
         const resolvedValue = resolveReferenceValue(key, val, referenceMap);
-        lines.push(`${indent}  - ${key}: ${formatPrimitive(resolvedValue)}.`);
+        const displayKey = formatReferenceKey(key, val, referenceMap);
+        lines.push(`${indent}  - ${displayKey}: ${formatPrimitive(resolvedValue)}`);
       }
     }
     return;
@@ -130,4 +146,5 @@ module.exports = {
   buildIgnoreSet,
   describeValue,
   collectNamedEntities,
+  formatReferenceKey,
 };


### PR DESCRIPTION
## Summary
- add a helper that renames referenced *Id fields to the `-xref` suffix in CTB output
- stop appending a trailing period to primitive property lines while keeping other formatting intact

## Testing
- node index.js --input examples/multi-records.json


------
https://chatgpt.com/codex/tasks/task_e_68d7f3fb847c8327ba02907f7645313e