### PR TITLE
Handle non-Node environments when writing output

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,10 @@ function jsonToCtb(data, options = {}) {
       throw new Error('The output option must be a non-empty string when provided.');
     }
 
+    if (typeof process === 'undefined' || typeof process.cwd !== 'function') {
+      throw new Error('File output requires a Node.js environment with process.cwd available.');
+    }
+
     const resolvedOutputPath = path.resolve(process.cwd(), output);
     fs.writeFileSync(resolvedOutputPath, `${result}\n`, 'utf8');
   }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "json2ctb": "./index.js"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test/jsonToCtb.test.js"
   },
   "keywords": [],
   "author": "",

--- a/test/jsonToCtb.test.js
+++ b/test/jsonToCtb.test.js
@@ -1,0 +1,73 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { jsonToCtb } = require('..');
+
+function runTest(name, fn) {
+  try {
+    fn();
+    console.log(`✓ ${name}`);
+  } catch (error) {
+    console.error(`✗ ${name}`);
+    console.error(error);
+    process.exitCode = 1;
+  }
+}
+
+runTest('jsonToCtb returns Canonical Text Block output for objects', () => {
+  const result = jsonToCtb({ hello: 'world' });
+  assert.ok(result.includes('hello: "world"'));
+});
+
+runTest('jsonToCtb writes to disk when output is provided in Node.js environments', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'json2ctb-'));
+  const outputPath = path.join(tempDir, 'output.ctb');
+
+  try {
+    const result = jsonToCtb({ key: 'value' }, { output: outputPath });
+    assert.ok(fs.existsSync(outputPath));
+    assert.strictEqual(fs.readFileSync(outputPath, 'utf8'), `${result}\n`);
+  } finally {
+    try {
+      fs.unlinkSync(outputPath);
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        throw error;
+      }
+    }
+  }
+});
+
+runTest('jsonToCtb throws a descriptive error when output is requested without process.cwd', () => {
+  const originalProcess = global.process;
+
+  try {
+    // Simulate a non-Node.js environment where process is not defined.
+    global.process = undefined;
+
+    assert.throws(
+      () => jsonToCtb({ name: 'Test' }, { output: 'out.ctb' }),
+      /requires a Node\.js environment/
+    );
+  } finally {
+    global.process = originalProcess;
+  }
+});
+
+runTest('jsonToCtb still returns output when process is unavailable and no file output is requested', () => {
+  const originalProcess = global.process;
+
+  try {
+    global.process = undefined;
+    const result = jsonToCtb({ greeting: 'hi' });
+    assert.ok(result.includes('greeting: "hi"'));
+  } finally {
+    global.process = originalProcess;
+  }
+});
+
+if (process.exitCode) {
+  process.exit(process.exitCode);
+}


### PR DESCRIPTION
## Summary
- guard file output in `jsonToCtb` so it requires a Node.js process with `process.cwd`
- add a lightweight test suite covering standard output, file writes, and process-less environments
- wire the npm test script to run the new tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9bac99c28832785628371152e1879