### PR TITLE
Defer CLI-only dependencies to Node environments

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,6 @@
 
 const fs = require('fs');
 const path = require('path');
-const yargs = require('yargs/yargs');
-const { hideBin } = require('yargs/helpers');
-
-
 const {
   DEFAULT_IGNORED_PROPERTIES,
   buildIgnoreSet,
@@ -50,6 +46,9 @@ function jsonToCtb(data, options = {}) {
 }
 
 if (require.main === module) {
+  const yargs = require('yargs/yargs');
+  const { hideBin } = require('yargs/helpers');
+
   const args = yargs(hideBin(process.argv))
     .usage('Usage: $0 --input <path> [options]')
     .option('input', {


### PR DESCRIPTION
## Summary
- require yargs and hideBin only when running the CLI entrypoint to avoid accessing process in browser bundles

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd3b23bf908327a7e72b8c130b805e