### PR TITLE
Convert json2ctb core to ESM and add browser-friendly entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,24 +8,39 @@ A Canonical Text Block is meant to be a natural-language representation of data.
 
 ## Usage
 
-initialize the module:
+The package now ships as an ES module that can be consumed from Node.js or bundled for the browser without pulling in Node-only dependencies.
 
-```
-import {JSON2CTB} from 'json2ctb'
-const json2ctb = new JSON2CTB(config)
+Generate a Canonical Text Block from a JavaScript value or JSON string:
+
+```js
+import { jsonToCtb } from 'json2ctb';
+
+const block = jsonToCtb({
+  id: 'user-123',
+  name: 'Ada Lovelace',
+  role: 'Engineer',
+});
+
+console.log(block);
 ```
 
-`config` is optional and may contain:
+The conversion accepts an optional `ignore` array that augments the default ignored keys (`['id', 'realmId', 'owner']`).
 
-```
-{
-    ignore: ['id', 'realmId', 'owner'],
-    output: undefined
-}
+```js
+const block = jsonToCtb(data, { ignore: ['createdAt', 'updatedAt'] });
 ```
 
-- `ignore`: An array of property names that should be excluded when rendering the Canonical Text Block.
-- `output`: An optional file path. When provided, the generated Canonical Text Block will be written to this location in addition to being returned.
+### Writing to disk in Node.js
+
+For Node.js workflows you can opt into synchronous file output by importing the Node-flavoured helper:
+
+```js
+import { jsonToCtbToFile } from 'json2ctb/node';
+
+const block = jsonToCtbToFile(data, { output: 'output.ctb' });
+```
+
+The helper resolves `output` relative to the current working directory and writes the rendered Canonical Text Block to disk.
 
 ## Examples
 

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+import yargs from 'yargs/yargs';
+import { hideBin } from 'yargs/helpers';
+
+import { jsonToCtb } from './index.js';
+
+const args = yargs(hideBin(process.argv))
+  .usage('Usage: $0 --input <path> [options]')
+  .option('input', {
+    alias: 'i',
+    type: 'string',
+    description: 'Path to the input JSON file.',
+    demandOption: true,
+  })
+  .option('ignore', {
+    alias: 'g',
+    type: 'array',
+    description: 'Properties to ignore in the output.',
+    coerce: (value) => (Array.isArray(value) ? value : [])
+      .flatMap((entry) => String(entry).split(','))
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+  })
+  .option('output', {
+    alias: 'o',
+    type: 'string',
+    description: 'Optional file path to write the Canonical Text Block.',
+  })
+  .help()
+  .alias('help', 'h')
+  .parse();
+
+const inputPath = args.input;
+
+if (!inputPath) {
+  console.error('Error: --input <path> is required.');
+  process.exit(1);
+}
+
+const resolvedPath = path.resolve(process.cwd(), inputPath);
+
+let fileContents;
+try {
+  fileContents = fs.readFileSync(resolvedPath, 'utf8');
+} catch (error) {
+  console.error(`Error: Unable to read file at ${resolvedPath}.`);
+  process.exit(1);
+}
+
+let parsed;
+try {
+  parsed = JSON.parse(fileContents);
+} catch (error) {
+  console.error('Error: Input file does not contain valid JSON.');
+  process.exit(1);
+}
+
+try {
+  const ctb = jsonToCtb(parsed, { ignore: args.ignore });
+
+  if (args.output) {
+    const resolvedOutputPath = path.resolve(process.cwd(), args.output);
+    fs.writeFileSync(resolvedOutputPath, `${ctb}\n`, 'utf8');
+  }
+
+  process.stdout.write(`${ctb}\n`);
+} catch (error) {
+  console.error(`Error: ${error.message}`);
+  process.exit(1);
+}

--- a/helpers.js
+++ b/helpers.js
@@ -1,6 +1,6 @@
-const DEFAULT_IGNORED_PROPERTIES = ['id', 'realmId', 'owner'];
+export const DEFAULT_IGNORED_PROPERTIES = ['id', 'realmId', 'owner'];
 
-function buildIgnoreSet(customIgnore) {
+export function buildIgnoreSet(customIgnore) {
   const ignore = new Set(DEFAULT_IGNORED_PROPERTIES);
   if (!customIgnore) {
     return ignore;
@@ -35,7 +35,7 @@ function formatPrimitive(value) {
   return String(value);
 }
 
-function collectNamedEntities(value, referenceMap = new Map()) {
+export function collectNamedEntities(value, referenceMap = new Map()) {
   if (Array.isArray(value)) {
     for (const item of value) {
       collectNamedEntities(item, referenceMap);
@@ -96,7 +96,7 @@ function formatReferenceKey(key, value, referenceMap) {
   return key;
 }
 
-function describeValue(value, ignoreSet, indentLevel, lines, referenceMap) {
+export function describeValue(value, ignoreSet, indentLevel, lines, referenceMap) {
   const indent = '  '.repeat(indentLevel);
 
   if (Array.isArray(value)) {
@@ -138,11 +138,3 @@ function describeValue(value, ignoreSet, indentLevel, lines, referenceMap) {
 
   lines.push(`${indent}${formatPrimitive(value)}.`);
 }
-
-module.exports = {
-  DEFAULT_IGNORED_PROPERTIES,
-  buildIgnoreSet,
-  describeValue,
-  collectNamedEntities,
-  formatReferenceKey,
-};

--- a/index.js
+++ b/index.js
@@ -1,112 +1,32 @@
-#!/usr/bin/env node
-
-const fs = require('fs');
-const path = require('path');
-const {
+import {
   DEFAULT_IGNORED_PROPERTIES,
   buildIgnoreSet,
   collectNamedEntities,
   describeValue,
-} = require('./helpers');
+} from './helpers.js';
 
-
-function jsonToCtb(data, options = {}) {
-  const { ignore, output } = options;
-  const ignoreSet = buildIgnoreSet(ignore);
-
-  let source = data;
-  if (typeof data === 'string') {
-    try {
-      source = JSON.parse(data);
-    } catch (error) {
-      throw new Error('Failed to parse JSON string input.');
-    }
+function ensureParsedSource(data) {
+  if (typeof data !== 'string') {
+    return data;
   }
 
+  try {
+    return JSON.parse(data);
+  } catch (error) {
+    throw new Error('Failed to parse JSON string input.');
+  }
+}
+
+export function jsonToCtb(data, options = {}) {
+  const { ignore } = options;
+  const ignoreSet = buildIgnoreSet(ignore);
+
+  const source = ensureParsedSource(data);
   const lines = ['Canonical Text Block', '--------------------'];
   const referenceMap = collectNamedEntities(source);
   describeValue(source, ignoreSet, 0, lines, referenceMap);
 
-  const result = lines.join('\n');
-
-  if (output !== undefined && output !== null) {
-    if (typeof output !== 'string' || !output.trim()) {
-      throw new Error('The output option must be a non-empty string when provided.');
-    }
-
-    if (typeof process === 'undefined' || typeof process.cwd !== 'function') {
-      throw new Error('File output requires a Node.js environment with process.cwd available.');
-    }
-
-    const resolvedOutputPath = path.resolve(process.cwd(), output);
-    fs.writeFileSync(resolvedOutputPath, `${result}\n`, 'utf8');
-  }
-
-  return result;
+  return lines.join('\n');
 }
 
-if (require.main === module) {
-  const yargs = require('yargs/yargs');
-  const { hideBin } = require('yargs/helpers');
-
-  const args = yargs(hideBin(process.argv))
-    .usage('Usage: $0 --input <path> [options]')
-    .option('input', {
-      alias: 'i',
-      type: 'string',
-      description: 'Path to the input JSON file.',
-      demandOption: true,
-    })
-    .option('ignore', {
-      alias: 'g',
-      type: 'array',
-      description: 'Properties to ignore in the output.',
-      coerce: (value) => (Array.isArray(value) ? value : [])
-        .flatMap((entry) => String(entry).split(','))
-        .map((entry) => entry.trim())
-        .filter(Boolean),
-    })
-    .option('output', {
-      alias: 'o',
-      type: 'string',
-      description: 'Optional file path to write the Canonical Text Block.',
-    })
-    .help()
-    .alias('help', 'h')
-    .parse();
-
-  const inputPath = args.input;
-
-  if (!inputPath) {
-    console.error('Error: --input <path> is required.');
-    process.exit(1);
-  }
-
-  const resolvedPath = path.resolve(process.cwd(), inputPath);
-
-  let fileContents;
-  try {
-    fileContents = fs.readFileSync(resolvedPath, 'utf8');
-  } catch (error) {
-    console.error(`Error: Unable to read file at ${resolvedPath}.`);
-    process.exit(1);
-  }
-
-  let parsed;
-  try {
-    parsed = JSON.parse(fileContents);
-  } catch (error) {
-    console.error('Error: Input file does not contain valid JSON.');
-    process.exit(1);
-  }
-
-  try {
-    const ctb = jsonToCtb(parsed, { ignore: args.ignore, output: args.output });
-    process.stdout.write(`${ctb}\n`);
-  } catch (error) {
-    console.error(`Error: ${error.message}`);
-    process.exit(1);
-  }
-}
-
-module.exports = { jsonToCtb, DEFAULT_IGNORED_PROPERTIES };
+export { DEFAULT_IGNORED_PROPERTIES };

--- a/node.js
+++ b/node.js
@@ -1,0 +1,21 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { jsonToCtb } from './index.js';
+
+export function jsonToCtbToFile(data, options = {}) {
+  const { output, ignore } = options;
+
+  if (output === undefined || output === null) {
+    throw new Error('The output option must be provided when writing to disk.');
+  }
+
+  if (typeof output !== 'string' || !output.trim()) {
+    throw new Error('The output option must be a non-empty string when provided.');
+  }
+
+  const result = jsonToCtb(data, { ignore });
+  const resolvedOutputPath = path.resolve(process.cwd(), output);
+  fs.writeFileSync(resolvedOutputPath, `${result}\n`, 'utf8');
+  return result;
+}

--- a/package.json
+++ b/package.json
@@ -2,9 +2,18 @@
   "name": "json2ctb",
   "version": "0.3.0",
   "description": "Ingest JSON data and excretes Canonical Text Blocks",
-  "main": "index.js",
+  "type": "module",
+  "main": "./index.js",
+  "exports": {
+    ".": {
+      "import": "./index.js",
+      "default": "./index.js"
+    },
+    "./node": "./node.js",
+    "./helpers": "./helpers.js"
+  },
   "bin": {
-    "json2ctb": "./index.js"
+    "json2ctb": "./cli.js"
   },
   "scripts": {
     "test": "node test/jsonToCtb.test.js"

--- a/test/jsonToCtb.test.js
+++ b/test/jsonToCtb.test.js
@@ -1,19 +1,22 @@
-const assert = require('assert');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
-const { jsonToCtb } = require('..');
+import { jsonToCtb } from '../index.js';
+import { jsonToCtbToFile } from '../node.js';
 
 function runTest(name, fn) {
-  try {
-    fn();
-    console.log(`✓ ${name}`);
-  } catch (error) {
-    console.error(`✗ ${name}`);
-    console.error(error);
-    process.exitCode = 1;
-  }
+  (async () => {
+    try {
+      await fn();
+      console.log(`\u2713 ${name}`);
+    } catch (error) {
+      console.error(`\u2717 ${name}`);
+      console.error(error);
+      process.exitCode = 1;
+    }
+  })();
 }
 
 runTest('jsonToCtb returns Canonical Text Block output for objects', () => {
@@ -21,12 +24,17 @@ runTest('jsonToCtb returns Canonical Text Block output for objects', () => {
   assert.ok(result.includes('hello: "world"'));
 });
 
-runTest('jsonToCtb writes to disk when output is provided in Node.js environments', () => {
+runTest('jsonToCtb parses JSON string input', () => {
+  const result = jsonToCtb('{"greeting":"hi"}');
+  assert.ok(result.includes('greeting: "hi"'));
+});
+
+runTest('jsonToCtbToFile writes to disk in Node.js environments', () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'json2ctb-'));
   const outputPath = path.join(tempDir, 'output.ctb');
 
   try {
-    const result = jsonToCtb({ key: 'value' }, { output: outputPath });
+    const result = jsonToCtbToFile({ key: 'value' }, { output: outputPath });
     assert.ok(fs.existsSync(outputPath));
     assert.strictEqual(fs.readFileSync(outputPath, 'utf8'), `${result}\n`);
   } finally {
@@ -40,31 +48,15 @@ runTest('jsonToCtb writes to disk when output is provided in Node.js environment
   }
 });
 
-runTest('jsonToCtb throws a descriptive error when output is requested without process.cwd', () => {
-  const originalProcess = global.process;
+runTest('jsonToCtb remains usable when process is unavailable', () => {
+  const originalProcess = globalThis.process;
 
   try {
-    // Simulate a non-Node.js environment where process is not defined.
-    global.process = undefined;
-
-    assert.throws(
-      () => jsonToCtb({ name: 'Test' }, { output: 'out.ctb' }),
-      /requires a Node\.js environment/
-    );
-  } finally {
-    global.process = originalProcess;
-  }
-});
-
-runTest('jsonToCtb still returns output when process is unavailable and no file output is requested', () => {
-  const originalProcess = global.process;
-
-  try {
-    global.process = undefined;
+    globalThis.process = undefined;
     const result = jsonToCtb({ greeting: 'hi' });
     assert.ok(result.includes('greeting: "hi"'));
   } finally {
-    global.process = originalProcess;
+    globalThis.process = originalProcess;
   }
 });
 


### PR DESCRIPTION
## Summary
- switch the package to ESM with explicit exports for the core module, CLI, and Node-specific helper
- update the library entry point to avoid Node-only dependencies and add a dedicated file-writing helper for Node
- refresh documentation and tests to cover the new API surface and ensure compatibility

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd3c440ea08327ae674b728f236172