### PR TITLE
Add dynamic titles and null handling to json2ctb output

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -61,6 +61,11 @@ try {
 try {
   const ctb = jsonToCtb(parsed, { ignore: args.ignore });
 
+  if (ctb === null) {
+    process.stdout.write('');
+    process.exit(0);
+  }
+
   if (args.output) {
     const resolvedOutputPath = path.resolve(process.cwd(), args.output);
     fs.writeFileSync(resolvedOutputPath, `${ctb}\n`, 'utf8');

--- a/entry.js
+++ b/entry.js
@@ -16,6 +16,10 @@ export function jsonToCtbToFile(data, options = {}) {
   }
 
   const result = jsonToCtb(data, { ignore })
+  if (result === null) {
+    return null
+  }
+
   const resolvedOutputPath = path.resolve(process.cwd(), output)
   fs.writeFileSync(resolvedOutputPath, `${result}\n`, 'utf8')
   return result

--- a/index.js
+++ b/index.js
@@ -5,9 +5,23 @@ import {
   describeValue,
 } from './helpers.js';
 
+const TITLE_KEYS = ['name', 'title', 'label'];
+
+function isPlainObject(value) {
+  return Object.prototype.toString.call(value) === '[object Object]';
+}
+
 function ensureParsedSource(data) {
+  if (data === null || data === undefined) {
+    return null;
+  }
+
   if (typeof data !== 'string') {
     return data;
+  }
+
+  if (!data.trim()) {
+    return null;
   }
 
   try {
@@ -17,12 +31,50 @@ function ensureParsedSource(data) {
   }
 }
 
+function isEmptyValue(value) {
+  if (value === null || value === undefined) {
+    return true;
+  }
+
+  if (typeof value === 'string') {
+    return value.trim() === '';
+  }
+
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+
+  if (isPlainObject(value)) {
+    return Object.keys(value).length === 0;
+  }
+
+  return false;
+}
+
 export function jsonToCtb(data, options = {}) {
   const { ignore } = options;
   const ignoreSet = buildIgnoreSet(ignore);
 
   const source = ensureParsedSource(data);
-  const lines = ['Canonical Text Block', '--------------------'];
+  if (isEmptyValue(source)) {
+    return null;
+  }
+
+  const lines = [];
+
+  if (isPlainObject(source)) {
+    const titleKey = TITLE_KEYS.find((key) => Object.prototype.hasOwnProperty.call(source, key));
+    if (titleKey) {
+      const rawTitle = source[titleKey];
+      if (rawTitle !== null && rawTitle !== undefined) {
+        const title = String(rawTitle).trim();
+        if (title) {
+          lines.push(title, '-'.repeat(title.length));
+        }
+      }
+    }
+  }
+
   const referenceMap = collectNamedEntities(source);
   describeValue(source, ignoreSet, 0, lines, referenceMap);
 

--- a/test/jsonToCtb.test.js
+++ b/test/jsonToCtb.test.js
@@ -24,9 +24,20 @@ runTest('jsonToCtb returns Canonical Text Block output for objects', () => {
   assert.ok(result.includes('hello: "world"'))
 })
 
+runTest('jsonToCtb uses root-level title properties when available', () => {
+  const result = jsonToCtb({ title: 'Example Object', value: 42 })
+  assert.ok(result.startsWith('Example Object\n--------------'))
+})
+
 runTest('jsonToCtb parses JSON string input', () => {
   const result = jsonToCtb('{"greeting":"hi"}')
   assert.ok(result.includes('greeting: "hi"'))
+})
+
+runTest('jsonToCtb returns null for empty inputs', () => {
+  assert.strictEqual(jsonToCtb({}), null)
+  assert.strictEqual(jsonToCtb(''), null)
+  assert.strictEqual(jsonToCtb(null), null)
 })
 
 runTest('jsonToCtbToFile writes to disk in Node.js environments', () => {


### PR DESCRIPTION
## Summary
- make jsonToCtb return null when provided empty or null input and avoid writing output downstream
- derive the Canonical Text Block title from root-level name, title, or label properties when available
- expand the test suite to cover the new behaviors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e114646ddc832780aae1dce8c238c7